### PR TITLE
[BASE-1396] Incorrect operation statistics.

### DIFF
--- a/src/main/java/com/emc/mongoose/storage/driver/preempt/PreemptStorageDriverBase.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/preempt/PreemptStorageDriverBase.java
@@ -57,6 +57,8 @@ public abstract class PreemptStorageDriverBase<I extends Item, O extends Operati
 	@Override
 	public final boolean put(final O op)  {
 		if(!isStarted()) {
+			op.status(FAIL_UNKNOWN);
+			Loggers.MSG.info("Failed with unknown status");
 			throwUnchecked(new EOFException());
 		}
 		final var submitted = incomingOpsLimiter.tryAcquire();

--- a/src/main/java/com/emc/mongoose/storage/driver/preempt/PreemptStorageDriverBase.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/preempt/PreemptStorageDriverBase.java
@@ -57,8 +57,6 @@ public abstract class PreemptStorageDriverBase<I extends Item, O extends Operati
 	@Override
 	public final boolean put(final O op)  {
 		if(!isStarted()) {
-			op.status(FAIL_UNKNOWN);
-			Loggers.MSG.info("Failed with unknown status");
 			throwUnchecked(new EOFException());
 		}
 		final var submitted = incomingOpsLimiter.tryAcquire();
@@ -76,8 +74,10 @@ public abstract class PreemptStorageDriverBase<I extends Item, O extends Operati
 		}
 		final var availablePermits = incomingOpsLimiter.availablePermits();
 		var n = to - from;
+		Loggers.MSG.info("Processing batch window: from - {}, to - {}, total - {} \n", from, to, n);
 		n = Math.min(availablePermits, n);
 		if(n > 0) {
+			Loggers.MSG.info("Acquiring N operations: {}", n);
 			if(incomingOpsLimiter.tryAcquire(n)) {
 				incomingOps.add(new ArrayList<>(ops).subList(from, from + n));
 				scheduledOpCount.add(n);
@@ -96,6 +96,7 @@ public abstract class PreemptStorageDriverBase<I extends Item, O extends Operati
 	final void prepareAndExecuteBatch(final List<O> ops) {
 		// should copy the ops into the other buffer as far as invoker will clean the source buffer after put(...) exit
 		final var n = ops.size();
+		Loggers.MSG.info("Processing batch size: {}", n);
 		final var opsRangeCopy = new ArrayList<O>(n);
 		O op;
 		for(var i = 0; i < n; i ++) {
@@ -103,6 +104,7 @@ public abstract class PreemptStorageDriverBase<I extends Item, O extends Operati
 			prepare(op);
 			opsRangeCopy.add(op);
 		}
+		Loggers.MSG.info("Batch size has been processed: {}", n);
 		execute(opsRangeCopy);
 	}
 

--- a/src/main/java/com/emc/mongoose/storage/driver/preempt/WorkerTask.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/preempt/WorkerTask.java
@@ -42,8 +42,10 @@ implements Runnable {
         try {
             while(true) {
                 final var ops = inQueue.poll();
+                Loggers.MSG.info("queue head is: {}", ops);
                 if(null == ops) {
                     final var state = stateSupplier.get();
+                    Loggers.MSG.info("curent state for queue head {} is {}", ops, state);
                     if(SHUTDOWN.equals(state)) {
                         Loggers.MSG.debug("{}: the state is shutdown and nothing to do more, exit", workerName);
                         break;
@@ -54,6 +56,7 @@ implements Runnable {
                         LockSupport.parkNanos(1);
                     }
                 } else {
+                    Loggers.MSG.info("Semaphore releases operations: {}", ops.size());
                     inQueueLimiter.release(ops.size());
                     batchAction.accept(ops);
                 }


### PR DESCRIPTION
**Expected behavior**
Reading from item-input-file with N lines gives you N succ operations

**Observed behaviour**
with 4.2.23 we don't get N succ operations, but somewhere around 90-95% of N. Other operations are left in pending state. 4.2.22 doesn't have this issue.

Related JIRA's issue: https://mongoose-issues.atlassian.net/browse/BASE-1396